### PR TITLE
Update main-menu_eo.properties

### DIFF
--- a/Guess the Animal/task/src/main/resources/main-menu_eo.properties
+++ b/Guess the Animal/task/src/main/resources/main-menu_eo.properties
@@ -1,9 +1,9 @@
 title       =Kion vi volas fari:
-play        =Ludu la divenludon
+play        =Ludi la divenludon
 search      =Serĉi beston
 list        =Listo de ĉiuj bestoj
-delete      =Forigu beston
-statistics  =Kalkulu statistikojn
-print       =Presu la Sciarbon
+delete      =Forigi beston
+statistics  =Kalkuli statistikojn
+print       =Printi la Sciarbon
 exit        =Eliri
-error       =Bonvolu enigi la numeron de 0 ĝis {0}
+error       =Bonvolu enigi numeron de 0 ĝis {0}


### PR DESCRIPTION
Presi is technically fine but printi might be better (ReVo tells me presi is often more so used in the sense of publically press/publish a text/book etc).
No need for u on the menu afaik, you're not telling the person to click there.
Wasn't really sure if "la" was needed for la numero? (Not sure of context, sorry I haven't been checking the English version.)