### PR TITLE
Update tree-services_eo.properties

### DIFF
--- a/Guess the Animal/task/src/main/resources/tree-services_eo.properties
+++ b/Guess the Animal/task/src/main/resources/tree-services_eo.properties
@@ -6,20 +6,20 @@ list.print      =\ - {0}
 search.animal   =Enigu la nomon de besto:
 search.facts    =Faktoj pri la {0}:
 search.print    =\ - {0}
-search.not_found=La besto ne estas en mia sciarbo.
+search.not_found=La besto ne estas en mia scioarbo.
 
 # Delete an animal
 delete.animal       = Enigu la nomon de besto:
 delete.root         = Ne eblas forigi la solan beston de la radiko.
 delete.successful   = La {0} estis forigita de la sciobazo.
-delete.fail         = La {0} ne troviĝis en la scio-bazo.
+delete.fail         = La {0} ne troviĝis en la sciobazo.
 
 # The Knowledge Tree Statistics
 # The messages formatted for printf function
 
 title       =La statistiko de la Scio-Arbo%n
 root        =- radika nodo                  %s%n
-nodes       =- tuta nombro de nodoj         %d%n
+nodes       =- totala nombro de nodoj         %d%n
 animals     =- totala nombro de bestoj      %d%n
 statements  =- totala nombro de deklaroj    %d%n
 height      =- alteco de la arbo            %d%n


### PR DESCRIPTION
It's just style, but you could change it to "totalo de" instead of "totala nombro de" for brevity.
"sola" seems a teensy bit weird here but I'm not sure why or what might replace it.
Changed "sciarbo" to "scioarbo" to make it more in line with the stats. You could possibly change stats to "Scioarbo". You might have to check what the "Printi la Scioarbon" was in the other section?
Once again, "entajpu" is an alternative to "enigu" if wanted.
I've just thought that the other section might have "statistikoj" instead of "statistiko", that could be changed to match this.